### PR TITLE
Adds option to display changset tags too

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ About the symbols before each line: `+` means that the tag is still applied, `-`
 ## Options
 
 * `-a LIST`, `--attribs LIST`: `LIST` is a comma-separated list of attributes to show (not including keys and values). Default is `user,version`. Possible attributes: `user`, `version`, `uid`, `changeset`, `timestamp`. Other attributes are possibles but vary from the element type. More informations about attributes on OpenStreetMap API documentation.
+* `-c LIST`, `--changeset-tags LIST`: `LIST` is a comma-separated list of changeset tags to show. Default is none, as it is slower due to more API calls. Common changeset tags: `created_by`, `comment`, `source`, `imagery_used`. Other changeset tags are possible but more rare, see https://wiki.openstreetmap.org/wiki/Changeset#Tags_on_changesets
 * `-d`, `--hide-deleted`: Do not show deleted tags.


### PR DESCRIPTION
Like `created_by`, `imagery_used` or any other [changeset tag](https://wiki.openstreetmap.org/wiki/Changeset#Tags_on_changesets). 

If not used, tool behaves as before. 
If specified, it does additional API calls to retrieve requested information (which are cached in memory to reduce unneeded API load).

e.g.

```
% osm-blame -c created_by,imagery_used,comment  way/554057154
    key               value           user                  version  created_by           imagery_used         comment
--  ----------------  --------------  ------------------  ---------  -------------------  -------------------  ----------------------------
+   building          house           Janjko                      2  Vespucci 10.2.0.3    Bing aerial imagery  fixes
+   addr:housenumber  34              Janjko                      2  Vespucci 10.2.0.3    Bing aerial imagery  fixes
+   addr:street       Javorska ulica  Janjko                      2  Vespucci 10.2.0.3    Bing aerial imagery  fixes
+   roof:material     roof_tiles      Venko                       3  JOSM/1.5 (13170 en)                       adding roof tags in Zagreb
+   roof:shape        gabled          Venko                       3  JOSM/1.5 (13170 en)                       adding roof tags in Zagreb
+   building:levels   1               mnalis ALTernative          4  StreetComplete 25.1                       Add building and roof levels
+   roof:levels       1               mnalis ALTernative          4  StreetComplete 25.1                       Add building and roof levels
```

Thanks for the nice nifty tool!